### PR TITLE
Avoid apostrophe appearing as left-single-quote

### DIFF
--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -150,7 +150,7 @@ Similarly, you can use dynamic arguments to bind a handler to a dynamic event na
 <a v-on:[eventName]="doSomething"> ... </a>
 ```
 
-In this example, when `eventName`'s value is `"focus"`, `v-on:[eventName]` will be equivalent to `v-on:focus`.
+In this example, when the value of `eventName` is `"focus"`, `v-on:[eventName]` will be equivalent to `v-on:focus`.
 
 #### Dynamic Argument Value Constraints
 


### PR DESCRIPTION
(At time of contribution, this is visible in the HTML rendering on https://vuejs.org/v2/guide/syntax.html, where you see:
eventName‘s  --- this has left single quote
eventName's  --- should have been an apostrophe

Rewording avoids this flaw in rendering. 

Someone may want to see if this occurs elsewhere in the documentation.